### PR TITLE
Add WaitCommand to RobotContainer, remove Timer.delay()

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -91,19 +91,19 @@ public final class Constants {
 
 	// Constant Speeds
 	public static final double drivePercentLimit = 1;
-	public static final double rotationMagnitude = 360;
 
 	public static final double armPercentSpeed = 0.4;
 
-	public static final double intakeVolts = 4;
+	public static final double intakeVolts = -4;
 	public static final double shooterVolts = 12;
 
-	public static final double conveyorVolts = 12;
+	public static final double inConveyorVolts = -12;
+	public static final double outConveyorVolts = 12;
 	
-	public static final double inPluckerVolts = 12;
+	public static final double inPluckerVolts = -12;
 	public static final double outPluckerVolts = 12;
 
-	public static final double intakeRPM = 1000;
+	public static final double intakeRPM = -1000;
 	public static final double shooterRPM = 3000;
 
 	public static final double colorSwitchSpeed = 0.2;

--- a/src/main/java/frc/robot/Gains.java
+++ b/src/main/java/frc/robot/Gains.java
@@ -46,8 +46,8 @@ public class Gains {
 
 	// Ramsete controller constants
 	public static class Ramsete {
-		public static final double kb = 2;
-		public static final double kzeta = 0.7;
+		public static final double kBeta = 2.0;
+		public static final double kZeta = 0.7;
 	}
 
 	// Feed Forward Constants

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -51,7 +51,7 @@ import static frc.robot.Gains.Ramsete.*;
  */
 public class RobotContainer {
   // Drive Controller
-  private XboxController xbox = new XboxController(Constants.kXboxPort);
+  private XboxController xbox = new XboxController(kXboxPort);
 
   // Drive Subsystem
   private final RevDrivetrain rDrive = new RevDrivetrain();
@@ -162,17 +162,17 @@ public class RobotContainer {
 
     // Shoot or intake with voltage, aiming for low goal
     new JoystickButton(xbox, kBumperLeft.value)
-    .whenPressed(() -> shooter.toggleSpeedVolts(), shooter)
-    .whenPressed(() -> conveyor.toggleSpeed(), shooter)
-    .whenPressed(() -> plucker.toggleSpeed(), plucker);
+    .whenPressed(new InstantCommand(() -> shooter.toggleSpeedVolts(), shooter))
+    .whenPressed(new InstantCommand(() -> conveyor.toggleSpeed(), shooter))
+    .whenPressed(new InstantCommand(() -> plucker.toggleSpeed(), plucker));
     
     // Shoot or intake with set velocity, specifically for high goal
     new JoystickButton(xbox, kB.value)
-    .whenPressed(() -> plucker.toggleSpeed(), plucker);
+    .whenPressed(new InstantCommand(() -> plucker.toggleSpeed(), plucker));
     
     // Toggles high shooting
     new JoystickButton(xbox, kY.value)
-    .whenPressed(() -> shooter.toggleSpeedSpark())
+    .whenPressed(new InstantCommand(() -> shooter.toggleSpeedSpark()))
     .whenPressed(new ConditionalCommand(waitAndFeed, stopFeeders, shooter::isEngaged));
 
     // Vision correction
@@ -186,10 +186,10 @@ public class RobotContainer {
 
     // Spin number of rotations
     new JoystickButton(xbox, kBack.value)
-    .whenPressed(() -> spinner.setCountColor(), spinner)
-    .whileHeld(() -> spinner.toSelectedColorSwitches(), spinner)
-    .whenReleased(() -> spinner.changeMaxSwitches(4), spinner)
-    .whenReleased(() -> spinner.move(0), spinner);
+    .whenPressed(new InstantCommand(() -> spinner.setCountColor(), spinner))
+    .whileHeld(new RunCommand(() -> spinner.toSelectedColorSwitches(), spinner))
+    .whenReleased(new InstantCommand(() -> spinner.changeMaxSwitches(4), spinner))
+    .whenReleased(new InstantCommand(() -> spinner.move(0), spinner));
 
     // Switch Gears
     new JoystickButton(xbox, kBumperRight.value)

--- a/src/main/java/frc/robot/Update.java
+++ b/src/main/java/frc/robot/Update.java
@@ -33,8 +33,6 @@ public class Update {
 
   private static final SendableChooser choosePosition = new SendableChooser<Pose2d>();
 
-
-
   public Update(SenseColor colorSensing, Shooter shooter, Spinner spinner) {
     m_shooter = shooter;
     colorSense = colorSensing;

--- a/src/main/java/frc/robot/shooter/ChangePosition.java
+++ b/src/main/java/frc/robot/shooter/ChangePosition.java
@@ -26,7 +26,7 @@ public class ChangePosition extends SubsystemBase {
     airow.start();
   }
 
-  public boolean getCollecting() {
+  public boolean isCollectingPose() {
     return collecting;
   }
 

--- a/src/main/java/frc/robot/shooter/ChangePosition.java
+++ b/src/main/java/frc/robot/shooter/ChangePosition.java
@@ -22,6 +22,7 @@ public class ChangePosition extends SubsystemBase {
 
   private boolean collecting = false;
   public boolean isSwapping = false;
+  
   public ChangePosition() {
     airow.start();
   }

--- a/src/main/java/frc/robot/shooter/Conveyor.java
+++ b/src/main/java/frc/robot/shooter/Conveyor.java
@@ -9,7 +9,6 @@ package frc.robot.shooter;
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import static frc.robot.Constants.*;
 

--- a/src/main/java/frc/robot/shooter/Conveyor.java
+++ b/src/main/java/frc/robot/shooter/Conveyor.java
@@ -15,61 +15,43 @@ import static frc.robot.Constants.*;
 
 public class Conveyor extends SubsystemBase {
   private ChangePosition goalMover;
-  private Shooter m_shooter;
 
   private WPI_TalonSRX conveyor = new WPI_TalonSRX(kConveyorPort);
 
+  private boolean engaged = false;
 
   /**
    * Creates a new Conveyor.
    */
-  public Conveyor(ChangePosition changePosition, Shooter shooter) {
+  public Conveyor(ChangePosition changePosition) {
     goalMover = changePosition;
-    m_shooter = shooter;
   }
 
   public void stop() {
-    setSpeedLowGoal(0);
+    conveyor.setVoltage(0);
+    engaged = false;
   }
 
+  public void collect() {
+    conveyor.setVoltage(inConveyorVolts);
+    engaged = true;
+  }
+
+  public void shoot() {
+    conveyor.setVoltage(outConveyorVolts);
+    engaged = true;
+  }
+  
   /**
    * Sets a voltage based on whether the robot is in low goal shooting position or
    * intake position. 
-   * @param beltVolts The voltage sent to the conveyor belt, changing direction
-   * depending on whether the shooter is in the intake or shooting position
    */
-
-  public void shoot(double beltVolts) {
-    conveyor.setVoltage(beltVolts);
-  }
-
-  public void collect(double beltVolts) {
-    conveyor.setVoltage(-beltVolts);
-  }
-
-  public void setSpeedLowGoal(double beltVolts){
-    if (goalMover.getCollecting()) {
-      collect(beltVolts);
+  public void setSpeed() {
+    if (goalMover.isCollectingPose()) {
+      collect();
 
     } else {
-      shoot(beltVolts);
-    }
-  }
-
-  /**
-   * Sets a voltage based on whether the robot is in high goal shooting position or
-   * intake position. 
-   * @param beltVolts The voltage sent to the conveyor belt, changing direction
-   * depending on whether the shooter is in the intake or shooting position
-   */
-  public void setSpeedHighGoal(double beltVolts){
-    if (goalMover.getCollecting()) {
-      conveyor.setVoltage(-beltVolts);
-
-    } else {
-      // Delays start up time when in shooting position
-      Timer.delay(shooterRampUpTime);
-      conveyor.setVoltage(beltVolts);
+      shoot();
     }
   }
 
@@ -78,24 +60,13 @@ public class Conveyor extends SubsystemBase {
    * with the specified voltage
    * @param beltVolts voltage applied to the conveyor when it is on
    */
-  public void toggleSpeedLowGoal(double beltVolts) {
-    if (m_shooter.isEngaged()) {
-      setSpeedLowGoal(beltVolts);
-    } else {
+  public void toggleSpeed() {
+    if (engaged) {
       stop();
-    }
-  }
 
-  /**
-   * Relying on the the shooter state, toggles conveyor on and off 
-   * with the specified voltage
-   * @param beltVolts voltage applied to the conveyor when it is on
-   */
-  public void toggleSpeedHighGoal(double beltVolts) {
-    if (m_shooter.isEngaged()) {
-      setSpeedHighGoal(beltVolts);
     } else {
-      stop();
+      setSpeed();
+
     }
   }
 

--- a/src/main/java/frc/robot/shooter/Plucker.java
+++ b/src/main/java/frc/robot/shooter/Plucker.java
@@ -16,54 +16,49 @@ import static frc.robot.Constants.*;
 
 public class Plucker extends SubsystemBase {
   private ChangePosition goalMover;
-  private Shooter m_shooter;
 
   private WPI_TalonSRX plucker = new WPI_TalonSRX(kPluckerPort);
+
+  private boolean engaged = false;
 
   /**
    * Creates a new Plucker.
    */
-  public Plucker(ChangePosition changePosition, Shooter shooter) {
+  public Plucker(ChangePosition changePosition) {
     goalMover = changePosition;
-    m_shooter = shooter;
   }
 
   public void stop() {
-    setSpeedLowGoal(0, 0);
+    plucker.setVoltage(0);
+    engaged = false;
   }
 
-  public void setSpeedLowGoal(double inVolts, double outVolts){
-    if (goalMover.getCollecting()) {
-      plucker.setVoltage(-inVolts);
+  public void collect() {
+    plucker.setVoltage(inPluckerVolts);
+    engaged = true;
+  }
+
+  public void shoot() {
+    plucker.setVoltage(outPluckerVolts);
+    engaged = true;
+  }
+
+  public void setSpeed(){
+    if (goalMover.isCollectingPose()) {
+      collect();
 
     } else {
-      plucker.setVoltage(outVolts);
+      shoot();
     }
   }
 
-  public void setSpeedHighGoal(double inVolts, double outVolts){
-    if (goalMover.getCollecting()) {
-      plucker.setVoltage(-inVolts);
-
-    } else {
-      Timer.delay(pluckerHoldTime);
-      plucker.setVoltage(outVolts);
-    }
-  }
-
-  public void toggleSpeedLowGoal(double inPluckerVolts, double outPluckerVolts) {
-    if (m_shooter.isEngaged()) {
-      setSpeedLowGoal(inPluckerVolts, outPluckerVolts);
-    } else {
+  public void toggleSpeed() {
+    if (engaged) {
       stop();
-    }
-  }
 
-  public void toggleSpeedHighGoal(double inPluckerVolts, double outPluckerVolts) {
-    if (m_shooter.isEngaged()) {
-      setSpeedHighGoal(inPluckerVolts, outPluckerVolts);
     } else {
-      stop();
+      setSpeed();
+
     }
   }
 

--- a/src/main/java/frc/robot/wheel/SenseColor.java
+++ b/src/main/java/frc/robot/wheel/SenseColor.java
@@ -21,9 +21,6 @@ import com.revrobotics.ColorMatchResult;
 import com.revrobotics.ColorMatch;
 
 public class SenseColor extends SubsystemBase {
-  /**
-   * Creates a new SenseColor.
-   */
   private final I2C.Port i2cPort = I2C.Port.kOnboard;
   private final ColorSensorV3 m_colorSensor = new ColorSensorV3(i2cPort);
   private int proximity = m_colorSensor.getProximity();
@@ -51,7 +48,6 @@ public class SenseColor extends SubsystemBase {
 
     GREEN(Constants.kGreenTarget,3,"G");
 
-    
     private final int position;
     private final String capital;
     private final Color target; 
@@ -62,6 +58,7 @@ public class SenseColor extends SubsystemBase {
       this.position = position;
       this.capital = capital;
     }
+
     /**
      * 
      * @param n = number of ofset color counterclockwise
@@ -71,7 +68,6 @@ public class SenseColor extends SubsystemBase {
       n = this.position + n % 4;
 
       if (n == YELLOW.position) {
-    
         return YELLOW;
       }
 
@@ -92,15 +88,11 @@ public class SenseColor extends SubsystemBase {
       }
     
     }
-   
-     
 
-    public String getCapital() {
-      return capital;
-    }
+  public String getCapital() {
+    return capital;
+  }
 
-    
-    
 	public static Colour fromString (final String Ch){
     switch(Ch){
     case("B"):
@@ -119,15 +111,6 @@ public class SenseColor extends SubsystemBase {
 
 }
   
-      
-
-
-
-
- 
-
-
-
   public double getRawColor() {
     IR = m_colorSensor.getIR();
     return IR;

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.17.3",
+    "version": "5.18.3",
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
         "http://devsite.ctr-electronics.com/maven/release/"
@@ -11,19 +11,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.17.3"
+            "version": "5.18.3"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.17.3"
+            "version": "5.18.3"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -35,7 +35,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -47,7 +47,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -69,7 +69,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -83,7 +83,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -111,7 +111,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -125,7 +125,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_PhoenixDiagnostics",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -139,7 +139,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_PhoenixCanutils",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -152,7 +152,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "platform-stub",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_PhoenixPlatform",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -165,7 +165,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.17.3",
+            "version": "5.18.3",
             "libName": "CTRE_PhoenixCore",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/REVColorSensorV3.json
+++ b/vendordeps/REVColorSensorV3.json
@@ -15,7 +15,7 @@
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "sourcesClassifier": "source",
-            "version": "1.0.0"
+            "version": "1.2.0"
         }
     ],
     "fileName": "REVColorSensorV3.json",
@@ -23,7 +23,7 @@
         {
             "artifactId": "ColorSensorV3-java",
             "groupId": "com.revrobotics.frc",
-            "version": "1.0.0"
+            "version": "1.2.0"
         }
     ],
     "jniDependencies": [],
@@ -33,5 +33,5 @@
     ],
     "name": "REVColorSensorV3",
     "uuid": "cda7b4b1-d003-44ac-a1ef-485c1347059a",
-    "version": "1.0.0"
+    "version": "1.2.0"
 }

--- a/vendordeps/REVRobotics.json
+++ b/vendordeps/REVRobotics.json
@@ -1,26 +1,54 @@
 {
-    "fileName": "REVRobotics.json",
-    "name": "REVRobotics",
-    "version": "1.5.1",
-    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
-    "mavenUrls": [
-        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    "cppDependencies": [
+        {
+            "artifactId": "SparkMax-cpp",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMax",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.2"
+        },
+        {
+            "artifactId": "SparkMax-driver",
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxaarch64bionic",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxraspbian"
+            ],
+            "groupId": "com.revrobotics.frc",
+            "headerClassifier": "headers",
+            "libName": "SparkMaxDriver",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "1.5.2"
+        }
     ],
-    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "fileName": "REVRobotics.json",
     "javaDependencies": [
         {
-            "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-java",
-            "version": "1.5.1"
+            "groupId": "com.revrobotics.frc",
+            "version": "1.5.2"
         }
     ],
     "jniDependencies": [
         {
-            "groupId": "com.revrobotics.frc",
             "artifactId": "SparkMax-driver",
-            "version": "1.5.1",
-            "skipInvalidPlatforms": true,
+            "groupId": "com.revrobotics.frc",
             "isJar": false,
+            "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "windowsx86",
@@ -28,43 +56,15 @@
                 "linuxx86-64",
                 "linuxathena",
                 "linuxraspbian"
-            ]
+            ],
+            "version": "1.5.2"
         }
     ],
-    "cppDependencies": [
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "SparkMax-cpp",
-            "version": "1.5.1",
-            "libName": "SparkMax",
-            "headerClassifier": "headers",
-            "sharedLibrary": false,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "windowsx86",
-                "linuxaarch64bionic",
-                "linuxx86-64",
-                "linuxathena",
-                "linuxraspbian"
-            ]
-        },
-        {
-            "groupId": "com.revrobotics.frc",
-            "artifactId": "SparkMax-driver",
-            "version": "1.5.1",
-            "libName": "SparkMaxDriver",
-            "headerClassifier": "headers",
-            "sharedLibrary": false,
-            "skipInvalidPlatforms": true,
-            "binaryPlatforms": [
-                "windowsx86-64",
-                "windowsx86",
-                "linuxaarch64bionic",
-                "linuxx86-64",
-                "linuxathena",
-                "linuxraspbian"
-            ]
-        }
-    ]
+    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVRobotics.json",
+    "mavenUrls": [
+        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+    ],
+    "name": "REVRobotics",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "version": "1.5.2"
 }

--- a/vendordeps/navx_frc.json
+++ b/vendordeps/navx_frc.json
@@ -1,7 +1,7 @@
 {
     "fileName": "navx_frc.json",
     "name": "KauaiLabs_navX_FRC",
-    "version": "3.1.400",
+    "version": "3.1.413",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
     "mavenUrls": [
         "https://repo1.maven.org/maven2/"
@@ -11,7 +11,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-java",
-            "version": "3.1.400"
+            "version": "3.1.413"
         }
     ],
     "jniDependencies": [],
@@ -19,7 +19,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-cpp",
-            "version": "3.1.400",
+            "version": "3.1.413",
             "headerClassifier": "headers",
             "sourcesClassifier": "sources",
             "sharedLibrary": false,
@@ -27,7 +27,8 @@
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "linuxathena",
-                "linuxraspbian"
+                "linuxraspbian",
+                "windowsx86-64"
             ]
         }
     ]


### PR DESCRIPTION
Fixes #1 by moving the waits up to the command level. In the RobotContainer, the Command Groups waitAndFeed and stopFeeders were created to create a delay in this thread of commands which would not impede on the drive at all, allowing only the shooter to be delayed.